### PR TITLE
Replace JNIEnv::isInstanceOf with ::IsInstanceOf

### DIFF
--- a/support-lib/jni/Marshal.hpp
+++ b/support-lib/jni/Marshal.hpp
@@ -289,7 +289,7 @@ namespace djinni
 		{
 			assert(j != nullptr);
 			const auto & data = JniClass<EitherJniInfo>::get();
-			assert(jniEnv->isInstanceOf(j, data.clazz.get()));
+			assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
 			auto isLeft = jniEnv->CallBooleanMethod(j, data.method_isLeft);
 			auto isRight = jniEnv->CallBooleanMethod(j, data.method_isRight);
 			assert(isLeft || isRight);


### PR DESCRIPTION
since JNIEnv::isInstanceOf doesn't exist. I guess this wasn't noticed
before since we were only making release builds.

@tonygoold Making a PR just to let you know. We can't make a debug build for the SDK on Android without this
